### PR TITLE
Add Content to About Us page.

### DIFF
--- a/_pages/about-us.md
+++ b/_pages/about-us.md
@@ -7,5 +7,18 @@ header:
  overlay_filter: "1"
 excerpt: "Learn more about OpenPrinting"
 ---
+## A Brief History
 
-Page under construction
+Before 2006, Linuxprinting.org and Free Software Group's OpenPrinting WorkGroup were working on printing architecture on Linux. Till Kamppeter was the manager of Linuxprinting.org and FSG's OpenPrinting WG was led by Tom Hastings, Micheal Sweet, Ira McDonald, and Claudia Alimpich. Linuxprinting.org was known as the *de facto* standard repository for printer drivers on Linux. In parallel, FSG's OpenPrinting workgroup designed standard APIs for Linux/Unix printing workflow.
+
+In July 2006 Linuxprinting.org merged with FSG's OP WorkGroup and Till Kamppeter was hired to oversee OpenPrinting. On January 22, 2007, the FSG and the Open Source Development Labs(OSDL) merged to form **The Linux Foundation**. Now, OpenPrinting is a free software organization under The Linux Foundation.
+
+## Major Roles
+
+OpenPrinting:
+* works on the development of new printing architectures, technologies, printing infrastructure, and interface standards for Linux and UNIX-style operating systems. 
+* collaborates with IEEE-ISTO Printer Working Group (PWG) on IPP projects. 
+* is working with SANE to make IPP scanning a reality.
+* maintains cups-filters which allows CUPS to be used on any Unix-based (non-macOS) system.
+* is responsible for the Foomatic database.
+* is working on Common Print Dialog Backends project.


### PR DESCRIPTION
@tillkamppeter I am not sure about the data. Please do have a look. 
I was not able to find any data on OpenPrinting WG and LinuxPrinting before they merged. It will be great to have a proper timeline on the about us page.
History of OpenPrinting is taken from https://lwn.net/Articles/191891/
and https://en.wikipedia.org/wiki/Free_Standards_Group.
Fixes #29. 