### PR TITLE
Correct link to Printers database.

### DIFF
--- a/_projects/02-foomatic.md
+++ b/_projects/02-foomatic.md
@@ -22,9 +22,13 @@ Foomatic consists of three packages:
 	<i class="fas fa-fw fa-link" aria-hidden="true"></i>
 	Downloads
 	</a>
-* <a href="http://www.openprinting.org/printer/" itemprop="sameAs" rel="nofollow noopener noreferrer">
+* <a href="http://www.openprinting.org/printers/" itemprop="sameAs" rel="nofollow noopener noreferrer">
 	<i class="fas fa-fw fa-link" aria-hidden="true"></i>
 	OpenPrinting - Printers
+	</a>
+* <a href="http://www.openprinting.org/drivers/" itemprop="sameAs" rel="nofollow noopener noreferrer">
+	<i class="fas fa-fw fa-link" aria-hidden="true"></i>
+	OpenPrinting - Drivers
 	</a>
 * <a href="http://www.openprinting.org/download/kpfeifle/LinuxKongress2002/Tutorial/IV.Foomatic-Developer/IV.tutorial-handout-foomatic-development.html" itemprop="sameAs" rel="nofollow noopener noreferrer">
 	<i class="fas fa-fw fa-link" aria-hidden="true"></i>

--- a/_projects/04-print-dialog.md
+++ b/_projects/04-print-dialog.md
@@ -22,8 +22,4 @@ If one opens the print dialog, the dialog will not talk directly to CUPS, Google
 * <a href="https://github.com/OpenPrinting/cpdb-backend-file" itemprop="sameAs" rel="nofollow noopener noreferrer">
    	<i class="fab fa-fw fa-github" aria-hidden="true"></i>GitHub - File(PDF) Backend
   	</a>
-
-* <a href="https://wiki.ubuntu.com/CommonPrintingDialog" itemprop="sameAs" rel="nofollow noopener noreferrer">
-	<i class="fas fa-fw fa-link" aria-hidden="true"></i>
-	Ubuntu Wiki
-	</a>
+  


### PR DESCRIPTION
Link to printers database is corrected. On the projects page, a link to "driver database" is added.  Also, the link to "Ubuntu Wiki" on the CPDB page has been removed. 