### PR TITLE
Fixed css for links

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -7,6 +7,21 @@
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
 
+/** For showing the blue links */
+.collection-list a:link,:visited	{
+	color: #0092ca;
+}
+.collection-list a:hover	{
+	color: #03A9F4;
+}
+
+.page__content a:link,:visited	{
+	color: #0092ca;
+}
+.page__content a:hover	{
+	color: #03A9F4;
+}
+
 .nav-logo{
 	height:2.2em;
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -7,18 +7,25 @@
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
 
-/** For showing the blue links */
-.collection-list a:link,:visited	{
-	color: #0092ca;
+/** For showling blue color in links etc */
+.archive__item-title a:link	{
+	color: #0092ca !important;
 }
-.collection-list a:hover	{
-	color: #03A9F4;
+.archive__item-title a:visited	{
+	color: #0092ca !important;
+}
+.archive__item-title a:hover	{
+	color: #03A9F4 !important;
 }
 
-.page__content a:link,:visited	{
+/** Specialy for gsoc links */
+a[href*="gsoc"]:link {
 	color: #0092ca;
 }
-.page__content a:hover	{
+a[href*="gsoc"]:visited {
+	color: #0092ca;
+}
+a[href*="gsoc"]:hover {
 	color: #03A9F4;
 }
 


### PR DESCRIPTION
Fixes #48 
Added the css in the main.scss file with checking all the pages.
The color of links was black, so changed it accordingly.

The Gsoc Page
![image](https://user-images.githubusercontent.com/56730716/94743455-0beca280-0395-11eb-93e9-c5891337cc7a.png)

The Upcoming tech page
![image](https://user-images.githubusercontent.com/56730716/94743546-2f175200-0395-11eb-8c1d-eff8d9f7dcd3.png)

The Projects page
![image](https://user-images.githubusercontent.com/56730716/94743609-48200300-0395-11eb-96c6-881a3597a8bb.png)

Also check that the rest of the pages are well.
@dheeraj135 check this and tell if any changes are needed.

_Browser used_ - Mozilla Firefox Version 80.0.1 in Ubuntu

