### PR TITLE
Added css to move table of content to right

### DIFF
--- a/_documentation/01-printer-application.md
+++ b/_documentation/01-printer-application.md
@@ -6,6 +6,8 @@ Ever wondered how a Printer works? What are the different steps involved between
 
 The following document contains information about the history of printing and its evolution. It describes Printer Applications. What were the issues with the previous methodologies? How Printer Applications helped in solving them? Why it has been referred to as the "Technology for Future"? In the end, it also contains roles of different entities including OpenPrinting, Manufacturers, and the User.  
 
+<div id="table-of-content" markdown="1">
+
 __Table of Contents__
 
 
@@ -14,7 +16,7 @@ __Table of Contents__
 3. **[Advantages of Printer Applications](#advantages)**
 4. **[Roles and Responsiblities](#roles)**
 5. **[Resources](#resources)**
-
+</div>
 
 
 <h2 id="brief-history"> Brief History </h2>

--- a/_documentation/01-printer-application.md
+++ b/_documentation/01-printer-application.md
@@ -1,5 +1,7 @@
 ---
 title: Printer Applications - A new way to print in Linux
+toc: true
+toc_sticky: true
 ---
 
 Ever wondered how a Printer works? What are the different steps involved between the print command and the final output?

--- a/_documentation/01-printer-application.md
+++ b/_documentation/01-printer-application.md
@@ -8,18 +8,6 @@ Ever wondered how a Printer works? What are the different steps involved between
 
 The following document contains information about the history of printing and its evolution. It describes Printer Applications. What were the issues with the previous methodologies? How Printer Applications helped in solving them? Why it has been referred to as the "Technology for Future"? In the end, it also contains roles of different entities including OpenPrinting, Manufacturers, and the User.  
 
-<div id="table-of-content" markdown="1">
-
-__Table of Contents__
-
-
-1. **[Brief History](#brief-history)**
-2. **[What is a Printer Application?](#printer-application)**
-3. **[Advantages of Printer Applications](#advantages)**
-4. **[Roles and Responsiblities](#roles)**
-5. **[Resources](#resources)**
-</div>
-
 
 <h2 id="brief-history"> Brief History </h2>
 The first release of CUPS was back in 1997. <sup><a href="https://openprinting.github.io/How-did-this-all-begin/">[1]</a></sup> Since then, Printer Drivers consisted of **PPD files** and **CUPS filters**.

--- a/_documentation/02-designing-printer-drivers.md
+++ b/_documentation/02-designing-printer-drivers.md
@@ -6,15 +6,6 @@ h_range: [1,2]
 ---
 **This document contains a complete tutorial as well as information for manufacturers with examples for designing printer drivers. If you are looking for information regarding the use of printer drivers, kindly refer to <a href="../05-User-Manual/">User Manual</a>**  
 
-__Table of Contents__
-
-
-1. **[Introduction](#introduction)**
-2. **[Components for PAPPL-based Printer Driver](#components)**
-3. **[Designing Components](#design)**
-4. **[Add Support for Non-Raster Printers](#non-raster)**
-5. **[Template for PAPPL-based Printer Driver](#template)**
-6. **[Resources](#resources)**
 
 <h2 id="introduction"> Introduction </h2>
 

--- a/_documentation/02-designing-printer-drivers.md
+++ b/_documentation/02-designing-printer-drivers.md
@@ -1,5 +1,8 @@
 ---
 title: Designing Printer Drivers
+toc: true
+toc_sticky: true
+h_range: [1,2]
 ---
 **This document contains a complete tutorial as well as information for manufacturers with examples for designing printer drivers. If you are looking for information regarding the use of printer drivers, kindly refer to <a href="../05-User-Manual/">User Manual</a>**  
 

--- a/_documentation/03-designing-scanner-drivers.md
+++ b/_documentation/03-designing-scanner-drivers.md
@@ -1,4 +1,6 @@
 ---
 title: Designing Scanner Drivers
+toc: true
+toc_sticky: true
 ---
 This document will contain a complete tutorial as well as information for manufacturers along examples for designing scanner drivers.

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -36,7 +36,22 @@ layout: default
           <aside class="sidebar__right {% if page.toc_sticky %}sticky{% endif %}">
             <nav class="toc">
               <header><h4 class="nav__title"><i class="fas fa-{{ page.toc_icon | default: 'file-alt' }}"></i> {{ page.toc_label | default: site.data.ui-text[site.locale].toc_label | default: "On this page" }}</h4></header>
-              {% include toc.html sanitize=true html=content h_min=1 h_max=6 class="toc__menu" %}
+              <!-- h_min is h_range[0] and h_max is h_range[1] -->
+              {% if page.h_range %}
+                <!-- YES h_min-->
+                {% if page.h_range[0]<=page.h_range[1] %}
+                  <!-- if you provided h_min and h_max take care you have h_min is smaller than or equal to h_max -->
+                  {% assign hmin = page.h_range[0] %}
+                  {% assign hmax = page.h_range[1] %}
+                  {% include toc.html sanitize=true html=content h_min=hmin h_max=hmax class="toc__menu" %}
+                {% else %}
+                  <!-- Default h range used as h_min is larger than h_max -->
+                  {% include toc.html sanitize=true html=content h_min=1 h_max=6 class="toc__menu" %}
+                {% endif %}
+              {% else %}
+                <!-- Default h range used -->
+                {% include toc.html sanitize=true html=content h_min=1 h_max=6 class="toc__menu" %}
+              {% endif %}
             </nav>
           </aside>
         {% endif %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -55,3 +55,12 @@
 	transition: all 0.2s ease-in-out;
 	-webkit-transition: all 0.2s ease-in-out;
 }
+
+@media (min-width: 1496px) {
+	#table-of-content {
+		position: fixed;
+		width: 320px;
+		top: 120px;
+		right: 8%;
+	}
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -56,11 +56,8 @@
 	-webkit-transition: all 0.2s ease-in-out;
 }
 
-@media (min-width: 1496px) {
-	#table-of-content {
-		position: fixed;
-		width: 320px;
-		top: 120px;
-		right: 8%;
+@media (min-width: 1284px) {
+	.sidebar__right {
+		margin-right: -400px; // Makes the Table of Content to more right than usual
 	}
 }


### PR DESCRIPTION
Fixes #105 
So so the Table of content written, we can enclose it in a div tag with markdown="1" and id="table-of-content"
The rest of css plays the role, and as @PIYUSHgoyal16 you wanted, it remains on the screen even on scroll.

I have added @ media rule, so that this only applies for large screen width devices, where there is space to move it to the right.

Currently I have added the div in only one documentation, check if this feels good, I will add it to more of the pages.
