### PR TITLE
Make text selection visible

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -141,7 +141,8 @@
     color: #ccc;
   }
   ::selection {
-    color: #ccc;
+    background: #ccc;
+    color: black;
   }
   .page__footer {
     color: #ccc !important;


### PR DESCRIPTION
Currently the text selection color scheme matches the non-selected
text color scheme which makes it impossible to see which block of
text is selected.  This inverts the selection colors.