### PR TITLE
Fix: Correct URL errors for Documentation pages and yarn.lock

### DIFF
--- a/contents/documentation/01-printer-application.md
+++ b/contents/documentation/01-printer-application.md
@@ -11,7 +11,7 @@ The following document contains information about the history of printing and it
 
 ## Brief History
 
-The first release of CUPS was back in 1997. <sup><a href="https://openprinting.github.io/How-did-this-all-begin/">[1]</a></sup> Since then, Printer Drivers consisted of **PPD files** and **CUPS filters**.
+The first release of CUPS was back in 1997. <sup><a href="/How-did-this-all-begin">[1]</a></sup> Since then, Printer Drivers consisted of **PPD files** and **CUPS filters**.
 
 **PPD (PostScript Printer Description)** is a decades-old data format created by Adobe, probably together with PostScript or shortly after, to describe capabilities and user-settable options of PostScript printers and which PostScript commands to embed in the print job to execute the option settings.
 
@@ -76,7 +76,7 @@ A **Printer Application's Web Interface** provides configurability and makes it 
 
     This is a complete printing stack in a Snap. It contains not only CUPS but also cups-filters, Ghostscript, and Poppler. It is everything which is required for printing, except Printer Drivers. Till Kamppeter has created this in order to provide a complete printing stack for a purely Snap-based Operating System.
 
-* <strong>PAPPL <sup><a href="https://github.com/michaelrsweet/pappl/">[3]</a></sup></strong> 
+* <strong>PAPPL <sup><a href="https://github.com/michaelrsweet/pappl">[3]</a></sup></strong> 
 
     Printer Applications have a lot in common. It would be a lot of re-inventing the wheel if everyone who wants to create a printer driver has to implement all this. Therefore Michael Sweet has created PAPPL, a library which provides all the common functionality which is needed in every Printer Application.
 
@@ -90,19 +90,19 @@ A **Printer Application's Web Interface** provides configurability and makes it 
 
     Currently, PAPPL supports only raster printers and that too for very few specific input formats like JPEG and PNG. For adding support for non-raster printers like PDF and PostScript printers, you need to supply an external utility that converts the whole job’s data into a data stream which the printer understands. Openprinting and CUPS Filters again come to the rescue here.
 
-    Manufacturers can use CUPS Filters to design these external utilities and decide which set of Filters to use and the order in which these should be invoked depending upon the efficiency and input-output formats. Kindly refer to guidelines for designing of printer applications<sup> <a href="../02-designing-printer-drivers/">[4]</a></sup> for more details.
+    Manufacturers can use CUPS Filters to design these external utilities and decide which set of Filters to use and the order in which these should be invoked depending upon the efficiency and input-output formats. Kindly refer to guidelines for designing of printer applications<sup> <a href="/documentation/02-designing-printer-drivers">[4]</a></sup> for more details.
 
 * <strong>Providing Sufficient Guidance</strong> 
     
-    OpenPrinting also helps the manufacturer about designing of printer <sup> <a href="../02-designing-printer-drivers/">[4]</a></sup> and scanner drivers.<sup><a href="../03-designing-scanner-drivers/">[5]</a></sup> It also guides them about packaging those drivers and uploading on Snap Store. <sup> <a href="../04-packaging-drivers/">[6]</a></sup>  It also educated users about using Printer Application Drivers. It provides neccessary documentation and tutorial for all the above mentioned things.<sup> <a href="../05-User-Manual/">[7]</a></sup>
+    OpenPrinting also helps the manufacturer about designing of printer <sup> <a href="/documentation/02-designing-printer-drivers">[4]</a></sup> and scanner drivers.<sup><a href="/documentation/03-designing-scanner-drivers">[5]</a></sup> It also guides them about packaging those drivers and uploading on Snap Store. <sup> <a href="/documentation/04-packaging-drivers">[6]</a></sup>  It also educated users about using Printer Application Drivers. It provides neccessary documentation and tutorial for all the above mentioned things.<sup> <a href="/documentation/05-User-Manual">[7]</a></sup>
 
  
 ### Manufacturer
 
-The Manufacturer besides manufacturing Printers and Scanners, is also expected to design drivers for the same. They can use PAPPL<sup><a href="https://github.com/michaelrsweet/pappl/">[3]</a></sup> library which certainly reduces their task to an great extent. Also they could take help from the documentation and tutorial developed by the OpenPrinting team. <sup> <a href="../02-designing-printer-drivers/">[4]</a></sup> 
-<sup> <a href="../03-designing-scanner-drivers/">[5]</a></sup>  
+The Manufacturer besides manufacturing Printers and Scanners, is also expected to design drivers for the same. They can use PAPPL<sup><a href="https://github.com/michaelrsweet/pappl">[3]</a></sup> library which certainly reduces their task to an great extent. Also they could take help from the documentation and tutorial developed by the OpenPrinting team. <sup> <a href="/documentation/02-designing-printer-drivers">[4]</a></sup> 
+<sup> <a href="/documentation/03-designing-scanner-drivers">[5]</a></sup>  
 
-After designing the drivers, they need to package them and Upload it to Snap Store. Again, documentation and tutorial for the same have developed by the OpenPrinting team which could be referred.<sup> <a href="../04-packaging-drivers/">[6]</a></sup> 
+After designing the drivers, they need to package them and Upload it to Snap Store. Again, documentation and tutorial for the same have developed by the OpenPrinting team which could be referred.<sup> <a href="/documentation/04-packaging-drivers">[6]</a></sup> 
 
 
 ### User
@@ -111,22 +111,22 @@ The user is relieved from most of the complexities and is just required to insta
 
 Further, he has the option to change his printer properties through the Web GUI provided with Printer Application.
 
-The OpenPrintring team has also worked out documentation and tutorials about installing CUPS and Drivers and using Web-based GUI, making the switch to this new technology easier for all.<sup> <a href="../05-User-Manual/">[7]</a></sup>
+The OpenPrintring team has also worked out documentation and tutorials about installing CUPS and Drivers and using Web-based GUI, making the switch to this new technology easier for all.<sup> <a href="/documentation/05-User-Manual">[7]</a></sup>
 
 ## Resources
 
-[1] <a href="https://openprinting.github.io/How-did-this-all-begin/">How all this began</a>
+[1] <a href="/How-did-this-all-begin">How all this began</a>
 <br>
 [2] <a href="https://github.com/OpenPrinting/cups-snap">CUPS Snap</a>
 <br>
-[3] <a href="https://github.com/michaelrsweet/pappl/">PAPPL</a>
+[3] <a href="https://github.com/michaelrsweet/pappl">PAPPL</a>
 <br>
-[4] <a href="../02-designing-printer-drivers/">Tutorial to Design Printer Drivers</a>
+[4] <a href="/documentation/02-designing-printer-drivers">Tutorial to Design Printer Drivers</a>
 <br>
-[5] <a href="../03-designing-scanner-drivers/">Tutorial to Design Scanner Drivers</a>
+[5] <a href="/documentation/03-designing-scanner-drivers">Tutorial to Design Scanner Drivers</a>
 <br>
-[6] <a href="../04-packaging-drivers/">Packaging Drivers and Uploading them to Snap Store</a>
+[6] <a href="/documentation/04-packaging-drivers">Packaging Drivers and Uploading them to Snap Store</a>
 <br>
-[7] <a href="../05-User-Manual/">User Manual</a>
+[7] <a href="/documentation/05-User-Manual">User Manual</a>
 <br>
 [8] <a href="https://github.com/OpenPrinting/cups-filters">CUPS Filters</a>

--- a/contents/documentation/02-designing-printer-drivers.md
+++ b/contents/documentation/02-designing-printer-drivers.md
@@ -4,14 +4,14 @@ toc: true
 toc_sticky: true
 h_range: [1,2]
 ---
-**This document contains a complete tutorial as well as information for manufacturers with examples for designing printer drivers. If you are looking for information regarding the use of printer drivers, kindly refer to <a href="../05-User-Manual/">User Manual</a>**  
+**This document contains a complete tutorial as well as information for manufacturers with examples for designing printer drivers. If you are looking for information regarding the use of printer drivers, kindly refer to <a href="/documentation/05-User-Manual">User Manual</a>**  
 
 
 <h2 id="introduction"> Introduction </h2>
 
-A driver is a code or data specific to a certain model or group of hardware devices, needed to make the hardware work with the hardware-model-independent code of the operating system. Printing in Linux has moved towards [Driverless Printing](https://openprinting.github.io/driverless/), which means there is no need for any hardware-model-specific code or data. However, there are some problems with the current framework. For example, some printers(especially the old ones) that cannot handle IPP requests are devoid of driverless printing capability. Printer Applications help to address these issues. Kindly refer <a href="../01-printer-application/">Printer Applications - A new way to print in Linux</a> to learn more about Printer Applications, its working and benefits.
+A driver is a code or data specific to a certain model or group of hardware devices, needed to make the hardware work with the hardware-model-independent code of the operating system. Printing in Linux has moved towards [Driverless Printing](https://openprinting.github.io/driverless), which means there is no need for any hardware-model-specific code or data. However, there are some problems with the current framework. For example, some printers(especially the old ones) that cannot handle IPP requests are devoid of driverless printing capability. Printer Applications help to address these issues. Kindly refer <a href="/documentation/01-printer-application">Printer Applications - A new way to print in Linux</a> to learn more about Printer Applications, its working and benefits.
 
-For Designing the Printer Application Driver, it would be a lot of re-inventing the wheel if everyone who wants to create a printer driver has to implement all things from scratch. Therefore Michael Sweet has developed <a href="https://github.com/michaelrsweet/pappl/">PAPPL</a>, a library that provides all the common functionality which is required in every Printer Application.
+For Designing the Printer Application Driver, it would be a lot of re-inventing the wheel if everyone who wants to create a printer driver has to implement all things from scratch. Therefore Michael Sweet has developed <a href="https://github.com/michaelrsweet/pappl">PAPPL</a>, a library that provides all the common functionality which is required in every Printer Application.
 
 The flowchart below mentions the components of the driver that needs to be designed by you (boxes in blue color), along with the PAPPL utilities (boxes in red color) that would be used by your designed components.
 
@@ -52,7 +52,7 @@ The following tutorial helps you to understand how to design each component and 
 
         The system is an object of type `pappl_system_t` that manages client and device connections, listeners, the log, printers, and resources. In addition, it provides an optional embedded web interface, raw socket printing, and USB printer gadget (Linux only).
 
-        The system callback argument specifies a function that will create a new system, i.e. a `pappl_system_t` object. You can use the callback function to customisably configure system properties using the <a href="../../pappl-system-utilities/">PAPPL System Utilities</a>. This includes configuring Footer HTML on your web interface and setting up drivers.
+        The system callback argument specifies a function that will create a new system, i.e. a `pappl_system_t` object. You can use the callback function to customisably configure system properties using the <a href="../../pappl-system-utilities">PAPPL System Utilities</a>. This includes configuring Footer HTML on your web interface and setting up drivers.
         
         You can refer [designing system callback](#systemcallback) guidelines for retrieving more information about the System Callback function.
 
@@ -348,7 +348,7 @@ ___
 
     4. **Add system configurations**
 
-        The system object has tons of configurable attributes and correspondingly a huge number of PAPPL utilities to configure them. These include utilities like Setting Hostname, Setting the footer HTML for the web interface, etc. A detailed list of these function can be found at <a href="../../pappl-system-utilities/">PAPPL System Utilities</a>. 
+        The system object has tons of configurable attributes and correspondingly a huge number of PAPPL utilities to configure them. These include utilities like Setting Hostname, Setting the footer HTML for the web interface, etc. A detailed list of these function can be found at <a href="../../pappl-system-utilities">PAPPL System Utilities</a>. 
 
 
     5. **Call the [Driver setup function](#setup)**
@@ -1035,16 +1035,16 @@ They must be independent of order application start at boot or of device discove
 
 <h2 id="resources"> Resources </h2>
 
-[1] <a href="../01-printer-application/">Printer Application</a>
+[1] <a href="/documentation/01-printer-application">Printer Application</a>
 <br>
 [2] <a href="https://github.com/michaelrsweet/hp-printer-app">HP Printer App Example</a>
 <br>
-[3] <a href="https://github.com/michaelrsweet/pappl/">PAPPL</a>
+[3] <a href="https://github.com/michaelrsweet/pappl">PAPPL</a>
 <br>
-[4] <a href="../../pappl-system-utilities/">PAPPL System Utilities</a>
+[4] <a href="../../pappl-system-utilities">PAPPL System Utilities</a>
 <br>
-[5] <a href="../04-packaging-drivers/">Packaging Drivers and Uploading them to Snap Store</a>
+[5] <a href="/documentation/04-packaging-drivers">Packaging Drivers and Uploading them to Snap Store</a>
 <br>
-[6] <a href="../05-User-Manual/">User Manual</a>
+[6] <a href="/documentation/05-User-Manual">User Manual</a>
 <br>
 [7] <a href="https://github.com/OpenPrinting/ps-printer-app">PS Printer App Example</a>

--- a/contents/documentation/03-designing-scanner-drivers.md
+++ b/contents/documentation/03-designing-scanner-drivers.md
@@ -10,9 +10,9 @@ h_range: [1,3]
 
 ## Introduction
 
-A driver is code or data specific to a certain model or group of hardware devices, needed to make the hardware work with the hardware-model-independent code of the operating system. Printing in Linux has moved towards [Driverless Printing](https://openprinting.github.io/driverless/) and so does Scanning, which means there is no need for any hardware-model-specific code or data. 
+A driver is code or data specific to a certain model or group of hardware devices, needed to make the hardware work with the hardware-model-independent code of the operating system. Printing in Linux has moved towards [Driverless Printing](../../driverless) and so does Scanning, which means there is no need for any hardware-model-specific code or data. 
 
-Kindly refer to <a href="../02-designing-printer-drivers/">Tutorial to Design Printer Drivers</a> to know more about Printer Applications and their designing. Designing Scanner Applications is very similar and expects the manufacturers to use the PAPPL framework to reduce their effort in implementing all things from scratch..
+Kindly refer to <a href="/documentation/02-designing-printer-drivers">Tutorial to Design Printer Drivers</a> to know more about Printer Applications and their designing. Designing Scanner Applications is very similar and expects the manufacturers to use the PAPPL framework to reduce their effort in implementing all things from scratch..
 
 ## How a PAPPL-based Scanner Driver should work
 
@@ -50,7 +50,7 @@ The scanner interface returns a single page at a time as uncompressed (or lossle
 
 PAPPL provides callbacks for most of the events including submitting print/scan jobs, querying printer/scanner status and capabilities, and so forth to reduce the manufacturer's workload and hence designing scanner applications is very much similar to designing printer applications. The only difference is the additional callback support provided for the scan command. Since this support is added in PAPPL, you as a manufacturer do not need to worry about this implementation as well.
 
-Hence refer to <a href="../02-designing-printer-drivers/">Tutorial to Design Printer Drivers</a> and follow the same for Designing Scanner Applications as well.
+Hence refer to <a href="/documentation/02-designing-printer-drivers">Tutorial to Design Printer Drivers</a> and follow the same for Designing Scanner Applications as well.
 
 ## Example for PAPPL-based Scanner Driver
 
@@ -97,10 +97,10 @@ They must be independent of order application start at boot or of device discove
 * **sane-airscan in SANE Scanner Application must be built without IPP Scan to avoid recursive discovery infinite loop (“Scanner bomb”)**
 
 ## Resources
-[1] <a href="../02-designing-printer-drivers/">Tutorial to Design Printer Drivers</a>
+[1] <a href="/documentation/02-designing-printer-drivers">Tutorial to Design Printer Drivers</a>
 <br>
-[2] <a href="https://github.com/michaelrsweet/pappl/">PAPPL</a>
+[2] <a href="https://github.com/michaelrsweet/pappl">PAPPL</a>
 <br>
-[3] <a href="../../pappl-system-utilities/">PAPPL System Utilities</a>
+[3] <a href="../../pappl-system-utilities">PAPPL System Utilities</a>
 <br>
-[4] <a href="../04-packaging-drivers/">Packaging Drivers and Uploading them to Snap Store</a>
+[4] <a href="/documentation/04-packaging-drivers">Packaging Drivers and Uploading them to Snap Store</a>

--- a/contents/documentation/04-packaging-drivers.md
+++ b/contents/documentation/04-packaging-drivers.md
@@ -4,7 +4,7 @@ toc: true
 toc_sticky: true
 h_range: [1,3]
 ---
-**This document contains a complete tutorial as well as information for manufacturers with examples for packaging printer/scanner drivers and releasing them to the Snap Store. If you are looking for information regarding the designing of printer/scanner drivers, kindly refer to <a href="../02-designing-printer-drivers/">Tutorial to Design Printer Drivers</a> and <a href="../03-designing-scanner-drivers/">Tutorial to Design Scanner Drivers</a> respectively.**  
+**This document contains a complete tutorial as well as information for manufacturers with examples for packaging printer/scanner drivers and releasing them to the Snap Store. If you are looking for information regarding the designing of printer/scanner drivers, kindly refer to <a href="/documentation/02-designing-printer-drivers">Tutorial to Design Printer Drivers</a> and <a href="/documentation/03-designing-scanner-drivers">Tutorial to Design Scanner Drivers</a> respectively.**  
 
 <h2 id="introduction"> Introduction </h2>
 
@@ -36,7 +36,7 @@ Most Snaps we create are driven using `snapcraft.yaml`. This file describes a sn
 
 As a distributor, you would create a `snapcraft.yaml` file. This will be used by the `snapcraft` command to build your snap. Next, you would upload this `.snap` file to the Snap Store and release it on the stable channel.
 
-To start building your snap, the initial step is to install snapcraft. Kindly refer the <a href="https://snapcraft.io/docs/installing-snapcraft">installation guidelines</a> to follow the same.
+To start building your snap, the initial step is to install snapcraft. Kindly refer the <a href="https://documentation.ubuntu.com/snapcraft/9.0/how-to/set-up-snapcraft">installation guidelines</a> to follow the same.
 
 After installation, navigate to the directory containing your application and use the following command.
 
@@ -291,9 +291,9 @@ Once you have a snap that works under strict or classic confinement, you’re re
 The further steps are extensively covered in the official documentation of Snaps and can be located at <a href="https://snapcraft.io/docs/releasing-to-the-snap-store">Releasing to Snap Documentation</a>.
 
 <h2 id="resources"> Resources </h2>
-[1] <a href="../02-designing-printer-drivers/">Tutorial to Design Printer Drivers</a>
+[1] <a href="/documentation/02-designing-printer-drivers">Tutorial to Design Printer Drivers</a>
 <br>
-[2] <a href="../03-designing-scanner-drivers/">Tutorial to Design Scanner Drivers</a>
+[2] <a href="/documentation/03-designing-scanner-drivers">Tutorial to Design Scanner Drivers</a>
 <br>
 [3] <a href="https://snapcraft.io/docs">Snap Documentation</a>
 <br>

--- a/contents/documentation/05-User-Manual.md
+++ b/contents/documentation/05-User-Manual.md
@@ -20,7 +20,7 @@ Further, many manufacturer's devices have options that cannot be translated into
 
 The Printer/Scanner Application you need to use depends on your printer's manufacturer, model and which classic driver supports it. We at OpenPrinting have developed Printer Applications covering printer drivers which are available in Debian/Ubuntu to provide retro-fitting (to keep the old devices working, but without adding new features) support for older devices which are currently supported in the distributions, and we provide the Legacy Printer Application for devices, which drivers are no longer supported by the manufacturer or they aren't in distributions for various reasons (no open-source license, no public source code, nobody packaged it...). The Legacy Printer Application is able to find classic drivers installed on the system and print on the supported printers. The PostScript Printer Application also allows uploading PPD files for printers via its web administration interface.
 
-We at OpenPrinting provide Printer Applications as Snaps, so these manuals contain Snap-related information. However distributions might provide Printer Applications packaged under classic packaging systems like DEB or RPM, or by another container solution, f.e. Podman or OCI containers. The exception is the Legacy Printer Application, which cannot be containerized due to its nature, so it is part of [pappl-retrofit](https://github.com/OpenPrinting/pappl-retrofit/) and can be shipped only by classic packaging systems.
+We at OpenPrinting provide Printer Applications as Snaps, so these manuals contain Snap-related information. However distributions might provide Printer Applications packaged under classic packaging systems like DEB or RPM, or by another container solution, f.e. Podman or OCI containers. The exception is the Legacy Printer Application, which cannot be containerized due to its nature, so it is part of [pappl-retrofit](https://github.com/OpenPrinting/pappl-retrofit) and can be shipped only by classic packaging systems.
 
 All the four Printer Applications currently available at OpenPrinting are only for retrofitting purposes and any new drivers should be written as native Printer/Scanner Applications, which can be shipped as a container (Snap, Podman, OCI containers) or via classic packaging systems. The Native Printer Applications can be provided by the printer's manufacturer or by community developers who have access to the printer.
 
@@ -51,7 +51,7 @@ Once `snap` is installed, you can easily install any driver. Find the name of th
     snap install <application-name>
 
 <br>
-*Note: Driver auto-installation i.e. when a printer on the system is discovered, the driver can be found on the Snap Store and even can be automatically installed using the hardware signature, is [under development](https://forum.snapcraft.io/t/hardware-associated-snaps-snap-store-search-by-hardware-signature/). We will update this work on our website as soon as this is completed. Until then you have to install drivers manually.*
+*Note: Driver auto-installation i.e. when a printer on the system is discovered, the driver can be found on the Snap Store and even can be automatically installed using the hardware signature, is [under development](https://forum.snapcraft.io/t/hardware-associated-snaps-snap-store-search-by-hardware-signature). We will update this work on our website as soon as this is completed. Until then you have to install drivers manually.*
 
 Many interfaces are automatically connected when a snap is installed, and this ability is a property of either the interface itself or the snap. Interfaces not connected automatically require the user to make a manual connection using the `snap connect` command.
 
@@ -398,7 +398,7 @@ ___
 
 ## Resources
 
-[1] <a href="../01-printer-application/">Printer Application</a>
+[1] <a href="/documentation/01-printer-application">Printer Application</a>
 <br>
 [2] <a href="https://snapcraft.io/docs">Snap Documentation</a>
 <br>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4995,13 +4995,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-expression-matcher@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "path-expression-matcher@npm:1.5.0"
-  checksum: 10c0/646cb5bc66cd7d809a52288336f3ac1e6223f156fd8e912936e490e590f7f93e8056d4fd25fcbcc7da61bb698fa520112cb050372a3f65e7b79bd4afa0f77610
-  languageName: node
-  linkType: hard
-
 "path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"


### PR DESCRIPTION
The URL on the Documentation page contained errors in the target URL, for example, when trying to go to "/documentation/05-User-Manual" it was only written as "/05-User-Manual." Several invalid URLs were also found on the Documentation page.

- Fixed errors for Documentation 01-Printer Application
- Fixed errors for Documentation 02-Designing Printer Drivers
- Fixed errors for Documentation 03-Designing Scanner Drivers
- Fixed errors for Documentation 04-Packaging Drivers
- Fixed errors for Documentation 05-User Manual
- Fixed errors for Snapcraft installation links
- Replaced several static URLs "https://openprinting.github.io/documentation/05-User-Manual" with "/documentation/05-User-Manual"
- Fixed several invalid URLs