### PR TITLE
minutes to read 

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -10,6 +10,7 @@ import authors from "@/data/authors"
 import { getAuthorImageSrc, getImageSrc } from "@/lib/utils"
 import { getTeaserImage } from "@/lib/get-latest-posts"
 import { siteConfig } from "@/config/site.config";
+import readingTime from "reading-time"
 
 type Post = {
   slug: string
@@ -49,13 +50,27 @@ export default async function NewsPage() {
           authorImage = getAuthorImageSrc(authorDef.image);
         }
 
+        const readTimeText = (() => {
+          const minutes = readingTime(content).minutes;
+
+          if (typeof data.readTime === "string" && data.readTime.trim()) {
+            return data.readTime.trim();
+          }
+
+          if (typeof data.readTime === "number" && Number.isFinite(data.readTime)) {
+            return `${Math.max(1, Math.round(data.readTime))} min read`;
+          }
+
+          return minutes < 1 ? "less than 1 minute read" : `${Math.max(1, Math.round(minutes))} min read`;
+        })();
+
         return {
           slug: file.replace(/\.md$/, ""),
-          title: typeof data.title === "string" ? data.title.replace(/\\/g, ""): file.replace(/\.md$/, ""),
+          title: typeof data.title === "string" ? data.title.replace(/\\/g, "") : file.replace(/\.md$/, ""),
           excerpt: typeof data.excerpt === "string" ? data.excerpt : "",
           date,
           year: date.getFullYear(),
-          readTime: typeof data.readTime === "string" ? data.readTime : "less than 1 minute read",
+          readTime: readTimeText,
           authorKey: authorKeyRaw,
           authorName: authorDef ? authorDef.name : authorKeyRaw,
           authorImage,


### PR DESCRIPTION
Fixes #225 

This PR improves the syntactical error in the /app/news/page.tsx . 

Problem -
 `readTime: typeof data.readTime === "string" ? data.readTime : "less than 1 minute read",`
 The project uses the readingTime package to calculate the time that is taken to read a particular article or news/ so if we are using readingTime then why we are passing **readTime as a string**.  so even if you pass it like that , there will be no use , It will always show **less than 1 minute read**. 

what I did - 

import the readingTime package pass it  to a function name readTimeText and calculate the time taken and render it , However if an article/news is taken less than 1 minute to read then show  less than 1 minute read. 

Hope this is what you are looking for. 
<img width="1011" height="923" alt="Screenshot from 2026-08-17 15-27-30" src="https://github.com/user-attachments/assets/ce957306-e05e-405a-a283-42c3942a2782" />
